### PR TITLE
Listen on all network interfaces

### DIFF
--- a/src/main/scala/io/radanalytics/equoid/DataPublisher.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataPublisher.scala
@@ -53,7 +53,7 @@ object DataPublisher {
     val service = system.actorOf(Props[PublisherServiceActor], "publisher-service")
     implicit val timeout = Timeout(5.seconds)
     // start a new HTTP server on port 8080 with our service actor
-    IO(Http) ? Http.Bind(service, interface = "localhost", port = port)
+    IO(Http) ? Http.Bind(service, interface = "0.0.0.0", port = port)
 
     opts.setReconnectAttempts(20)
         .setTrustAll(true)


### PR DESCRIPTION
This is required for the service in openshift to be reachable after exposing it via route.
With this change, I was able to add new frequent items by:

```bash
curl -X POST -d "foo" http://equoid-data-publisher-new-publisher.10.19.47.15.nip.io/api | less
```