### PR TITLE
Artemis usage

### DIFF
--- a/src/main/scala/io/radanalytics/equoid/DataPublisher.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataPublisher.scala
@@ -75,7 +75,8 @@ object DataPublisher {
     opts.setReconnectAttempts(20)
         .setTrustAll(true)
         .setConnectTimeout(10000) // timeout = 10sec, reconnect interval is 1sec
-    client.connect(opts, amqpHost, amqpPort, username, password, new Handler[AsyncResult[ProtonConnection]] {
+    //client.connect(opts, amqpHost, amqpPort, username, password, new Handler[AsyncResult[ProtonConnection]] {
+    client.connect(opts, amqpHost, amqpPort, new Handler[AsyncResult[ProtonConnection]] {
       override def handle(ar: AsyncResult[ProtonConnection]): Unit = {
         if (ar.succeeded()) {
 


### PR DESCRIPTION
Modified to work with the Artemis image from redhat-iot rather than the A-MQ image from jboss-openshift. 